### PR TITLE
Remove the cluster_previous_image workaround

### DIFF
--- a/roles/cluster_infra/tasks/main.yml
+++ b/roles/cluster_infra/tasks/main.yml
@@ -17,25 +17,6 @@
       }
     dest: "{{ terraform_project_path }}/backend.tf"
 
-# Patching in this appliance is implemented as a switch to a new base image
-# So unless explicitly patching, we want to use the same image as last time
-# To do this, we query the previous Terraform state before updating
-- block:
-    - name: Get previous Terraform state
-      stackhpc.terraform.terraform_output:
-        binary_path: "{{ terraform_binary_path }}"
-        project_path: "{{ terraform_project_path }}"
-        backend_config: "{{ terraform_backend_config }}"
-      register: cluster_infra_terraform_output
-
-    - name: Extract image from Terraform state
-      set_fact:
-        cluster_previous_image: "{{ cluster_infra_terraform_output.outputs.cluster_image.value }}"
-      when: '"cluster_image" in cluster_infra_terraform_output.outputs'
-  when:
-    - terraform_state == "present"
-    - cluster_upgrade_system_packages is not defined or not cluster_upgrade_system_packages
-
 - name: Template Terraform files into project directory
   template:
     src: "{{ item }}.j2"

--- a/roles/cluster_infra/templates/outputs.tf.j2
+++ b/roles/cluster_infra/templates/outputs.tf.j2
@@ -1,5 +1,5 @@
 # This is used to determine the image to use unless explicitly patching
 output "cluster_image" {
   description = "The id of the image used to build the cluster nodes"
-  value       = "{{ cluster_previous_image | default(cluster_image) }}"
+  value       = "{{ cluster_image }}"
 }

--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -43,7 +43,7 @@ resource "openstack_blockstorage_volume_v3" "data_volume" {
 
 resource "openstack_compute_instance_v2" "cluster_server" {
   name      = "{{ cluster_name }}-{{ cluster_type }}"
-  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
+  image_id  = "{{ cluster_image }}"
   flavor_id = "{{ cluster_flavor }}"
 
   network {


### PR DESCRIPTION
The caas operator always sends the correct image via extra_vars, so we can remove the cluster_previous_image workaround.